### PR TITLE
Improving sweep library API and functionality

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -13,6 +13,7 @@ pub enum BlibError {
     WriteNewVal { err: std::io::Error, dev: String },
     ReadMax,
     ReadCurrent,
+    SweepError(std::io::Error),
 }
 
 #[doc(hidden)]
@@ -56,6 +57,8 @@ impl std::fmt::Display for BlibError {
             ReadCurrent => write!(f, "Failed to read current brightness value"),
 
             ReadMax => write!(f, "Failed to read max brightness value"),
+
+            SweepError(err) => write!(f, "Failed to sweep write to brightness file ({err})"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,14 +244,17 @@ impl Device {
         Ok(())
     }
 
-    /// Writes to the brightness file in an increment of 1% on each loop until change value is reached.
-    /// Each loop has a delay of 25ms, to produce to a smooth sweeping effect when executed.
+    /// Writes to the brightness file starting from the current value in a loop, increasing 1% on each iteration with some delay until target value is reached,
+    /// creating a smooth brightness transition.
     ///
     /// This method takes a target value, which can be computed with the help of [``Device::calculate_change``] or can also be manually entered.
-    /// Nothing is written to the brightness file if the provided value is the same as current brightness value or is larger than the max brightness value.
+    /// The delay between each iteration of the loop can be set using the [``Delay``] type, or the default can be used by calling [``Delay::default()``],
+    /// which sets the delay of 25ms/iter (recommended).
+    ///
+    /// Note: Nothing is written to the brightness file if the provided value is the same as current brightness value or is larger than the max brightness value.
     /// # Errors
     /// Possible errors that can result from this function include:
-    /// * [``BlibError::WriteNewVal``]
+    /// * [``BlibError::SweepError``]
     pub fn sweep_write(&self, value: u16, delay: Delay) -> Result<(), BlibError> {
         let mut bfile = self.open_bl_file().map_err(BlibError::SweepError)?;
         let mut rate = (f32::from(self.max) * 0.01) as u16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,12 @@ pub fn set_bl(val: u16, device_name: Option<Cow<str>>) -> Result<(), BlibError> 
 pub fn sweep(device: &Device, change: u16, dir: Direction) -> Result<(), BlibError> {
     let mut rate = (f32::from(device.max) * 0.01) as u16;
     let mut val = device.current;
-    while val != change {
+
+    while !(val == change
+        || change > device.max
+        || (val == 0 && dir == Direction::Dec)
+        || (val == device.max && dir == Direction::Inc))
+    {
         match dir {
             Direction::Inc => {
                 if (val + rate) > change {
@@ -284,7 +289,9 @@ pub fn sweep(device: &Device, change: u16, dir: Direction) -> Result<(), BlibErr
                 val += rate;
             }
             Direction::Dec => {
-                if (val - rate) < change {
+                if rate > val {
+                    rate = val;
+                } else if (val - rate) < change {
                     rate = val - change;
                 }
                 val -= rate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,7 @@ impl Device {
     /// Possible errors that can result from this function include:
     /// * [``BlibError::WriteNewVal``]
     pub fn sweep_write(&self, value: u16) -> Result<(), BlibError> {
+        let mut bfile = self.open_bl_file().map_err(BlibError::SweepError)?;
         let mut rate = (f32::from(self.max) * 0.01) as u16;
         let mut current = self.current;
         let dir = if value > self.current {
@@ -248,7 +249,8 @@ impl Device {
                     current -= rate;
                 }
             }
-            self.write_value(current)?;
+            bfile.rewind().map_err(BlibError::SweepError)?;
+            write!(bfile, "{current}").map_err(BlibError::SweepError)?;
             thread::sleep(Duration::from_millis(25));
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,6 +430,32 @@ mod tests {
         assert_eq!(ch, 0);
     }
 
+    #[test]
+    fn sweeping() {
+        clean_up();
+        setup_test_env(&["generic"]).unwrap();
+        let mut d = test_device("generic");
+        d.sweep_write(100).unwrap();
+        d.reload();
+        assert_eq!(d.current, 100);
+        d.sweep_write(0).unwrap();
+        d.reload();
+        assert_eq!(d.current, 0);
+        clean_up();
+    }
+
+    #[test]
+    fn sweep_bounds() {
+        clean_up();
+        setup_test_env(&["generic"]).unwrap();
+        let mut d = test_device("generic");
+        d.write_value(0).unwrap();
+        d.sweep_write(u16::MAX).unwrap();
+        d.reload();
+        assert_eq!(d.current, 0);
+        clean_up();
+    }
+
     fn setup_test_env(dirs: &[&str]) -> Result<(), Box<dyn Error>> {
         fs::create_dir(TESTDIR)?;
         for dir in dirs {
@@ -438,6 +464,15 @@ mod tests {
             fs::write(format!("{TESTDIR}/{dir}/max"), "100")?;
         }
         Ok(())
+    }
+
+    fn test_device(name: &str) -> Device {
+        Device {
+            name: name.into(),
+            current: 50,
+            max: 100,
+            device_dir: format!("{TESTDIR}/{name}"),
+        }
     }
 
     fn clean_up() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! > If you're only using blight as a dependency, you can read about gaining file permissions [here](https://wiki.archlinux.org/title/Backlight#ACPI).
 //!
 //! # Usage
-//! ```
+//! ```ignore
 //! use blight::{BlResult, Change, Device, Direction, Delay};
 //!
 //! fn main() -> BlResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@
 use err::BlibError;
 use std::{
     borrow::Cow,
-    fs,
+    fs::{self, File},
+    io::prelude::*,
     path::{Path, PathBuf},
     thread,
     time::Duration,
@@ -163,6 +164,12 @@ impl Device {
         } else {
             Err(BlibError::NoDeviceFound)
         }
+    }
+
+    fn open_bl_file(&self) -> Result<File, std::io::Error> {
+        let mut path = self.device_path().to_path_buf();
+        path.push("brightness");
+        fs::File::options().write(true).open(path)
     }
 
     /// Reloads current value for the current device in place.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use std::{
     borrow::Cow,
     fs::{self, File},
     io::prelude::*,
+    ops::Deref,
     path::{Path, PathBuf},
     thread,
     time::Duration,
@@ -61,6 +62,39 @@ pub enum Change {
     #[default]
     Regular,
     Sweep,
+}
+
+/// A wrapper type for [``std::time::Duration``] used for specifying delay between each iteration of the loop in [``Device::sweep_write``].
+///
+/// Delay implements the Default trait, which always returns a Delay of 25ms (recommended delay for smooth brightness transisions).
+/// The struct also provides the [``from_millis``] constructor, if you'd like to set your own duration in milliseconds.
+/// If you'd like to set the delay duration using units other than milliseconds, then you can use the From trait to create Delay using [Duration][std::time::Duration].
+#[derive(Debug, Clone, Copy)]
+pub struct Delay(Duration);
+
+impl From<Duration> for Delay {
+    fn from(value: Duration) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for Delay {
+    type Target = Duration;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for Delay {
+    fn default() -> Self {
+        Self(Duration::from_millis(25))
+    }
+}
+
+impl Delay {
+    pub fn from_millis(millis: u64) -> Self {
+        Self(Duration::from_millis(millis))
+    }
 }
 
 /// An abstraction of a backlight device containing a name, current and max backlight values, and some related functionality.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,13 @@
 //! ```
 
 use err::BlibError;
-use std::{borrow::Cow, fs, path::PathBuf, thread, time::Duration};
+use std::{
+    borrow::Cow,
+    fs,
+    path::{Path, PathBuf},
+    thread,
+    time::Duration,
+};
 
 pub mod err;
 pub use err::BlResult;
@@ -121,6 +127,10 @@ impl Device {
             device_dir,
             name: name.into(),
         })
+    }
+
+    pub fn device_path(&self) -> &Path {
+        self.device_dir.as_ref()
     }
 
     fn detect_device(bldir: &str) -> BlResult<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,10 +193,11 @@ impl Device {
         Ok(())
     }
 
-    /// This function takes a borrow of a Device instance, a [calculated change][calculate_change] value and the [Direction].
-    ///
-    /// It writes to the brightness file in an increment of 1% on each loop until change value is reached.
+    /// Writes to the brightness file in an increment of 1% on each loop until change value is reached.
     /// Each loop has a delay of 25ms, to produce to a smooth sweeping effect when executed.
+    ///
+    /// This method takes a target value, which can be computed with the help of [``Device::calculate_change``] or can also be manually entered.
+    /// Nothing is written to the brightness file if the provided value is the same as current brightness value or is larger than the max brightness value.
     /// # Errors
     /// Possible errors that can result from this function include:
     /// * [``BlibError::WriteNewVal``]


### PR DESCRIPTION
The sweep functionality which was available as a helper function in the library will now be part of the Device struct as a method named `sweep_write`. This is a breaking change, but I think it's worth it as it greatly simplifies the user-facing API and adds to the overall uniformity of the crate as `sweep_write` is similar to `write_value`.

Checks have also been added to both avoid panics caused by integer overflow ( fixes #1 ) and to avoid writing beyond the max brightness value of the backlight device.

Update:
Using this opportunity, the sleep duration or delay between each iteration of the loop (delay between each incremental write to the brightness file) has been exposed through the new Delay parameter in the sweep_write function, letting the users have more control.

This can be used as `device.sweep_write(10, Delay::default())` (default delay of 25ms) or `device.sweep_write(10, Delay::from_millis(25))`.  Since Delay is a wrapper type for `std::time::duration`, Duration type can easily be converted into Delay type by calling `into()` like so: `device.sweep_write(10, Duration::from_millis(25).into())`

Another notable change includes the use of a single file handle inside sweep_write for all writes. (Before, `Device::write_value` was called on each write inside the loop, which in-turn used `std::fs::write`). Users may notice a slight improvement in the smoothness of the brightness transition.

### todo
- [x] Add missing unit tests
- [x] Review code to look for improvement opportunities
- [x] Update all docs to reflect new changes