### PR TITLE
Increase brightness type to u32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blight"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "colored",
  "fs4",

--- a/src/err.rs
+++ b/src/err.rs
@@ -14,7 +14,7 @@ pub enum BlibError {
     ReadMax,
     ReadCurrent,
     SweepError(std::io::Error),
-    ValueTooLarge { given: u16, supported: u16 },
+    ValueTooLarge { given: u32, supported: u32 },
 }
 
 #[doc(hidden)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,8 +36,8 @@ enum Command {
     Save,
     Restore,
     List,
-    Adjust { dir: Direction, value: u16 },
-    Set(u16),
+    Adjust { dir: Direction, value: u32 },
+    Set(u32),
 }
 
 #[derive(Default)]
@@ -82,7 +82,7 @@ pub fn parse<'a>(mut args: Skip<Args>) -> Result<Config<'a>, DynError> {
             "save" => (Save, option_parser(args)),
 
             "set" => {
-                let val: u16 = args
+                let val: u32 = args
                     .next()
                     .ok_or(MissingValue)?
                     .parse()
@@ -92,7 +92,7 @@ pub fn parse<'a>(mut args: Skip<Args>) -> Result<Config<'a>, DynError> {
             }
 
             ch @ ("inc" | "dec") => {
-                let value: u16 = args
+                let value: u32 = args
                     .next()
                     .ok_or(MissingValue)?
                     .parse()
@@ -337,7 +337,7 @@ pub fn restore() -> Result<(), DynError> {
     let (device_name, val) = restore.split_once(' ').unwrap();
     let device = Device::new(Some(device_name.into()))?;
 
-    let value: u16 = val.parse().map_err(|_| BlightError::SaveParseErr)?;
+    let value: u32 = val.parse().map_err(|_| BlightError::SaveParseErr)?;
     device.write_value(value)?;
     Ok(())
 }


### PR DESCRIPTION
~Turns out the [i915 driver](https://github.com/torvalds/linux/blob/190bf7b14b0cf3df19c059061be032bd8994a597/drivers/gpu/drm/i915/display/intel_backlight.c) for intel chips uses `u32` to represent brightness levels, instead of~ The linux kernel uses `int`/`i32` as [documented](https://www.kernel.org/doc/html/latest/gpu/backlight.html#c.backlight_properties) to represent `max_brightness` values and so my `i7-8565U` ends up with a max brightness of `120000`, which blight would refuse to parse into an u16.

```bash
$ cargo run status
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/blight status`
Device status
Detected device: intel_backlight
Write permission: Ok
Current brightness: 120000
```

This pr therefore increases the type for brightness values to u32, to support ~weird intel behavior~ `max_brightness` values higher than `u16::MAX`.