### PR TITLE
11 switch to std lib file locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,10 @@
 version = 4
 
 [[package]]
-name = "bitflags"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
 name = "blight"
 version = "0.7.1"
 dependencies = [
  "colored",
- "fs4",
 ]
 
 [[package]]
@@ -23,27 +16,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fs4"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -53,46 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.153"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
@@ -101,28 +40,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -132,22 +56,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -156,22 +68,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -180,31 +80,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,17 @@ exclude = ["*.png", ".github/workflows"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-colored = "2.0.3"
-fs4 = { version = "0.6.6", features = ["sync"] }
+colored = { version = "2.0.3", optional = true }
+
+[features]
+default = ["cli"]
+locking = []
+cli = ["locking", "dep:colored"]
+
+[[bin]]
+name = "blight"
+path = "src/main.rs"
+required-features = ["cli"]
 
 [profile.release]
 strip = true

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,8 @@
 - library support for LED interface (`/sys/class/leds`) 🎉
 - `toggle` method to toggle between min and max supported brightness values
   - Mainly intended to be used for LEDs, but is also available on the `Device` type
+- `Device::new_locked` method to init a backlight device with an exclusive lock on the brightness file
+  - A method of the same name also exists for the `Led` type
 
 ### Improved
 - Better and cleaner implementation of the code that reads brightness values from ASCII text
@@ -11,6 +13,8 @@
 - All doc tests are set to `no_run` instead of `ignore`, to ensure all doc examples compile
 - All successful write operations update the `current` brightness value in `self`
   - This makes calling `reload` after a write optional and is required only if brightness values were modified by an external process
+- CLI deps are now behind a feature gate (enabled by default)
+  - library users are now recommended to use `cargo add --no-default-features`
 
 ### Changed
 - [BREAKING!] `sweep_write` returns `ErrorKind::ValueTooLarge` if the provided value is larger than `max` (same as `write_value`) instead of silently ignoring it
@@ -22,6 +26,8 @@
 - [BREAKING!] `device_path` method now returns a `&Path` instead of a `PathBuf`
 - `blight::Result` is now the preferred type alias for the result type, not `blight::BlResult`
  - The old type alias is still included
+- [BREAKING!] Migrated from `fs4` to std lib based file locking for CLI
+  - This raises the MSRV to `1.89.0` (only for CLI and lib users with `locking` feature enabled)
 
 # Version 0.7.1
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -62,13 +62,24 @@ impl std::error::Error for Error {
 /// The `Display` trait impl provides human-friendly, descriptive messages for each variant.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorKind {
-    ReadDir { dir: &'static str },
+    ReadDir {
+        dir: &'static str,
+    },
     ReadMax,
     ReadCurrent,
-    WriteValue { device: String },
-    ValueTooLarge { given: u32, supported: u32 },
+    WriteValue {
+        device: String,
+    },
+    ValueTooLarge {
+        given: u32,
+        supported: u32,
+    },
     SweepError,
     NotFound,
+    #[cfg(feature = "locking")]
+    LockError {
+        blocked: bool,
+    },
 }
 
 impl std::fmt::Display for ErrorKind {
@@ -91,6 +102,14 @@ impl std::fmt::Display for ErrorKind {
                 f,
                 "provided value '{given}' is larger than the max supported value of '{supported}'"
             ),
+            #[cfg(feature = "locking")]
+            ErrorKind::LockError { blocked } => {
+                if *blocked {
+                    write!(f, "failed to acquire exclusive lock on the brightness file as it's already locked")
+                } else {
+                    write!(f, "failed to acquire exclusive lock on the brightness file")
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "cli")]
+
 use std::env;
 
 mod utils;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,15 +4,7 @@ use blight::{
     Light, BLDIR,
 };
 use colored::Colorize;
-use fs4::FileExt;
-use std::{
-    borrow::Cow,
-    env,
-    env::Args,
-    fs::{self, File, OpenOptions},
-    iter::Skip,
-    path::PathBuf,
-};
+use std::{borrow::Cow, env, env::Args, fs, iter::Skip, path::PathBuf};
 
 mod setup;
 
@@ -123,12 +115,22 @@ pub fn execute(conf: Config) -> Result<SuccessMessage, DynError> {
         Save => save(conf.options.device)?,
         Restore => restore()?,
         Set(v) => {
-            let _lock = acquire_lock()?;
-            blight::set_bl(v, conf.options.device)?
+            // Same impl as blight::set_bl but with file locking
+            let mut device = new_locked(conf.options.device)?;
+            if v != device.current() {
+                device.write_value(v)?;
+            }
         }
         Adjust { dir, value } => {
-            let _lock = acquire_lock()?;
-            blight::change_bl(value, conf.options.sweep, dir, conf.options.device)?
+            // Same impl as blight::change_bl but with file locking
+            let mut device = new_locked(conf.options.device)?;
+            let change = device.calculate_change(value, dir);
+            if change != device.current() {
+                match conf.options.sweep {
+                    Change::Sweep => device.sweep_write(change, blight::Delay::default())?,
+                    Change::Regular => device.write_value(change)?,
+                }
+            }
         }
     };
 
@@ -149,7 +151,6 @@ pub enum BlightError {
     ReadFromSave(std::io::Error),
     NoSaveFound,
     SaveParseErr,
-    LockFailure(std::io::Error),
 }
 
 impl Tip for BlightError {
@@ -164,9 +165,6 @@ impl Tip for BlightError {
             }
             ReadFromSave(_) => Some("make sure you have read permission for the save file".into()),
             SaveParseErr => Some("delete the save file and try save-restore again".into()),
-            LockFailure(_) => {
-                Some(format!("try manually removing the lock file: `{LOCKFILE}`").into())
-            }
             _ => None,
         }
     }
@@ -184,7 +182,6 @@ impl std::fmt::Display for BlightError {
             ReadFromSave(err) => write!(f, "failed to read from save file\n{err}"),
             NoSaveFound => write!(f, "no save file found"),
             SaveParseErr => write!(f, "failed to parse saved brightness value"),
-            LockFailure(err) => write!(f, "failed to acquire lock\n{err}"),
         }
     }
 }
@@ -193,7 +190,7 @@ impl std::error::Error for BlightError {}
 
 impl Tip for blight::Error {
     fn tip(&self) -> Option<Cow<'static, str>> {
-        use blight::ErrorKind::WriteValue;
+        use blight::ErrorKind::{LockError, WriteValue};
         match self.kind() {
             WriteValue { device } => {
                 let tip_msg = format!(
@@ -206,6 +203,9 @@ or visit https://wiki.archlinux.org/title/Backlight#Hardware_interfaces
 if you'd like to do it manually.",
                 );
                 Some(tip_msg.into())
+            }
+            LockError { .. } => {
+                Some(format!("try manually removing the lock file: `{LOCKFILE}`").into())
             }
             _ => None,
         }
@@ -398,20 +398,17 @@ impl PanicReporter {
     }
 }
 
-fn acquire_lock() -> Result<File, DynError> {
-    let file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(LOCKFILE)
-        .map_err(BlightError::LockFailure)?;
-    if file.try_lock_exclusive().is_ok() {
-        return Ok(file);
-    }
-    println!(
-        "{} {}",
-        "Status".magenta().bold(),
-        "Waiting for another instance to finish"
-    );
-    file.lock_exclusive().map_err(BlightError::LockFailure)?;
-    Ok(file)
+fn new_locked(name: Option<Cow<str>>) -> Result<Device, DynError> {
+    let device = match Device::new_locked(name.clone(), false) {
+        Err(err) if *err.kind() == blight::ErrorKind::LockError { blocked: true } => {
+            println!(
+                "{} Waiting for another instance to finish",
+                "Status".magenta().bold(),
+            );
+            Device::new_locked(name, true)
+        }
+        other => other,
+    }?;
+
+    Ok(device)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -379,7 +379,7 @@ impl PanicReporter {
             std::panic::set_hook(Box::new(Self::report));
         }
     }
-    fn report(info: &std::panic::PanicInfo) {
+    fn report(info: &std::panic::PanicHookInfo) {
         let tip = "This is unexpected behavior. Please report this issue at https://github.com/VoltaireNoir/blight/issues";
         let payload = info.payload();
         let cause = if let Some(pay) = payload.downcast_ref::<&str>() {


### PR DESCRIPTION
This PR removes dependency on the `fs4` crate in favor of the new std lib's file locking impl. The `new_locked` method is added on both `Device` and `Led` to initialize them with an exclusive lock on the brightness file. This functionality requires `locking` feature to be enabled.

The only CLI related dependency (`coloured`) is now behind the `cli` feature flag, which is enabled by default.